### PR TITLE
Simplify SplitMode ergonomics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,13 +18,18 @@ dependencies = [
 
 [[package]]
 name = "atty"
-version = "0.2.14"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "hermit-abi 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termion 1.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "autocfg"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bitflags"
@@ -66,12 +71,22 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "chrono"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-integer 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "clap"
 version = "2.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -119,16 +134,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "hermit-abi"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "itoa"
 version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "lazy_static"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -156,6 +168,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "num-integer"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "numtoa"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ppv-lite86"
@@ -216,6 +250,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "redox_termios"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "redox_syscall 0.1.57 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "regex"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -265,6 +312,18 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "stderrlog"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -282,6 +341,7 @@ dependencies = [
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stderrlog 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "symlink 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-normalization 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -300,6 +360,25 @@ dependencies = [
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "termion"
+version = "1.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "numtoa 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.57 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -330,10 +409,29 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thread_local"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "time"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.57 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -355,8 +453,21 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "unreachable"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "vec_map"
 version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "void"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -428,6 +539,14 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -435,24 +554,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [metadata]
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-"checksum atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+"checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
+"checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum bstr 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3ede750122d9d1f87919570cb2cccee38c84fbc8c5599b25c289af40625b7030"
 "checksum bumpalo 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1f359dc14ff8911330a51ef78022d376f25ed00248912803b58f00cb1c27f742"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+"checksum chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum csv 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "11f8cbd084b9a431d52dfac0b8428a26b68f1061138a7bea18aa56b9cdf55266"
 "checksum csv-core 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9b5cadb6b25c77aeff80ba701712494213f4a8418fcda2ee11b6560c3ad0bf4c"
 "checksum encoding_rs 0.8.22 (registry+https://github.com/rust-lang/crates.io-index)" = "cd8d03faa7fe0c1431609dfad7bbe827af30f82e1e2ae6f7ee4fca6bd764bc28"
 "checksum getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
-"checksum hermit-abi 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "eff2656d88f158ce120947499e971d743c05dbcbed62e5bd2f38f1698bbc3772"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
+"checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum memchr 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3197e20c7edb283f87c071ddfc7a2cca8f8e0b888c242959846a6fce03c72223"
+"checksum num-integer 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
+"checksum num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)" = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
+"checksum numtoa 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
 "checksum ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 "checksum proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3acb317c6ff86a4e579dfa00fc5e6cca91ecbb4e7eb2df0468805b674eb88548"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
@@ -460,6 +584,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "03a2a90da8c7523f554344f921aa97283eadf6ac484a6d2a7d0212fa7f8d6853"
 "checksum rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 "checksum rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+"checksum redox_syscall 0.1.57 (registry+https://github.com/rust-lang/crates.io-index)" = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
+"checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum regex 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b5508c1941e4e7cb19965abef075d35a9a8b5cdf0846f30b4050e9b55dc55e87"
 "checksum regex-automata 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "92b73c2a1770c255c240eaa4ee600df1704a38dc3feaa6e949e7fcd4f8dc09f9"
 "checksum regex-syntax 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "e734e891f5b408a29efbf8309e656876276f49ab6a6ac208600b4419bd893d90"
@@ -467,17 +593,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449"
 "checksum serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)" = "48c575e0cc52bdd09b47f330f646cf59afc586e9c4e3ccd6fc1f625b8ea1dad7"
 "checksum smallvec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44e59e0c9fa00817912ae6e4e6e3c4fe04455e75699d06eedc7d85917ed8e8f4"
+"checksum stderrlog 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "32e5ee9b90a5452c570a0b0ac1c99ae9498db7e56e33d74366de7f2a7add7f25"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum symlink 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 "checksum syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)" = "af6f3550d8dff9ef7dc34d384ac6f107e5d31c8f57d9f28e0081503f547ac8f5"
+"checksum termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
+"checksum termion 1.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "c22cec9d8978d906be5ac94bceb5a010d885c626c4c8855721a4dbd20e3ac905"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thiserror 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "6f357d1814b33bc2dc221243f8424104bfe72dbe911d5b71b3816a2dff1c977e"
 "checksum thiserror-impl 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "eb2e25d25307eb8436894f727aba8f65d07adf02e5b35a13cebed48bd282bfef"
+"checksum thread_local 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1697c4b57aeeb7a536b647165a2825faddffb1d3bad386d507709bd51a90bb14"
 "checksum thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
+"checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum unicode-normalization 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b561e267b2326bb4cebfc0ef9e68355c7abe6c6f522aeac2f5bf95d56c59bdcf"
 "checksum unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+"checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
+"checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)" = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 "checksum wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "5205e9afdf42282b192e2310a5b463a6d1c1d774e30dc3c791ac37ab42d2616c"
 "checksum wasm-bindgen-backend 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "11cdb95816290b525b32587d76419facd99662a07e59d3cdb560488a819d9a45"
@@ -486,4 +619,5 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum wasm-bindgen-shared 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "f5e7e61fc929f4c0dddb748b102ebf9f632e2b8d739f2016542b4de2965a9601"
 "checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+"checksum winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0.44"
 lazy_static = "1.4.0"
 clap = "2.33.0"
 thiserror = "1.0.9"
+stderrlog = "0.4"
 symlink = "0.1.0"
 
 [features]

--- a/README.md
+++ b/README.md
@@ -41,11 +41,16 @@ $ sudachiclone -h
 Japanese Morphological Analyzer
 
 USAGE:
-    sudachiclone [SUBCOMMAND]
+    sudachiclone [FLAGS] [OPTIONS] [SUBCOMMAND]
 
 FLAGS:
     -h, --help       Prints help information
+    -q               Silence all output
     -V, --version    Prints version information
+    -v               Increase message verbosity
+
+OPTIONS:
+    -z <timestamp>        prepend timestamp to log lines [possible values: none, sec, ms, ns]
 
 SUBCOMMANDS:
     build       Build Sudachi Dictionary
@@ -57,7 +62,7 @@ SUBCOMMANDS:
 
 ```bash
 $ sudachiclone tokenize -h
-sudachiclone-tokenize
+sudachiclone-tokenize 0.2.1
 Tokenize Text
 
 USAGE:
@@ -66,14 +71,13 @@ USAGE:
 FLAGS:
     -h, --help       (default) see `tokenize -h`
     -a               print all of the fields
-    -d               print the debug information
     -V, --version    Prints version information
-    -v               print sudachipy version
 
 OPTIONS:
     -o <fpath_out>            the output file
     -r <fpath_setting>        the setting file in JSON format
     -m <mode>                 the mode of splitting [possible values: A, B, C]
+    -p <python_exe>           path to Python executable
 
 ARGS:
     <in_files>...    text written in utf-8
@@ -92,8 +96,8 @@ FLAGS:
     -V, --version    Prints version information
 
 OPTIONS:
-    -t <dict_type>        dict dict [default: core]  [possible values: small, core, full]
-```
+    -t <dict_type>         dict dict [default: core]  [possible values: small, core, full]
+    -p <python_exe>        path to Python executable```
 
 ```bash
 $ sudachiclone build -h
@@ -123,53 +127,53 @@ Here is an example usage:
 ```rust
 use sudachiclone::prelude::*;
 
-let dictionary = Dictionary::new(None, None).unwrap();
+let dictionary = Dictionary::setup(None, None, None).unwrap();
 let tokenizer = dictionary.create();
 
 // Multi-granular tokenization
 // using `system_core.dic` or `system_full.dic` version 20190781
 // you may not be able to replicate this particular example due to dictionary you use
 
-for m in tokenizer.tokenize("国家公務員", &Some(SplitMode::C), None).unwrap() {
+for m in tokenizer.tokenize("国家公務員", Some(SplitMode::C), None).unwrap() {
     println!("{}", m.surface());
 };
-# => 国家公務員
+// => 国家公務員
 
-for m in tokenizer.tokenize("国家公務員", &Some(SplitMode::B), None).unwrap() {
+for m in tokenizer.tokenize("国家公務員", Some(SplitMode::B), None).unwrap() {
     println!("{}", m.surface());
 };
-# => 国家
-# => 公務員
+// => 国家
+// => 公務員
 
-for m in tokenizer.tokenize("国家公務員", &Some(SplitMode::A), None).unwrap() {
+for m in tokenizer.tokenize("国家公務員", Some(SplitMode::A), None).unwrap() {
     println!("{}", m.surface());
 };
-# => 国家
-# => 公務
-# => 員
+// => 国家
+// => 公務
+// => 員
 
 // Morpheme information
 
-let m = tokenizer.tokenize("食べ", &Some(SplitMode::A), None).unwrap().get(0).unwrap();
+let m = tokenizer.tokenize("食べ", Some(SplitMode::A), None).unwrap().get(0).unwrap();
 println!("{}", m.surface());
-# => 食べ
+// => 食べ
 println!("{}", m.dictionary_form());
-# => 食べる
+// => 食べる
 println!("{}", m.reading_form());
-# => タベ
+// => タベ
 println!("{:?}", m.part_of_speech());
-# => ["動詞", "一般", "*", "*", "下一段-バ行", "連用形-一般"]
+// => ["動詞", "一般", "*", "*", "下一段-バ行", "連用形-一般"]
 
 // Normalization
 
-println!("{}", tokenizer.tokenize("附属", &Some(SplitMode::A), None).unwrap().get(0).unwrap().normalized_form());
-# => 付属
+println!("{}", tokenizer.tokenize("附属", Some(SplitMode::A), None).unwrap().get(0).unwrap().normalized_form());
+// => 付属
 
-println!("{}", tokenizer.tokenize("SUMMER", &Some(SplitMode::A), None).unwrap().get(0).unwrap().normalized_form());
-# => サマー
+println!("{}", tokenizer.tokenize("SUMMER", Some(SplitMode::A), None).unwrap().get(0).unwrap().normalized_form());
+// => サマー
 
-println!("{}", tokenizer.tokenize("シュミレーション", &Some(SplitMode::A), None).unwrap().get(0).unwrap().normalized_form());
-# => シミュレーション
+println!("{}", tokenizer.tokenize("シュミレーション", Some(SplitMode::A), None).unwrap().get(0).unwrap().normalized_form());
+// => シミュレーション
 ```
 
 ## License

--- a/src/config.rs
+++ b/src/config.rs
@@ -172,12 +172,13 @@ fn get_python_package_path_helper(python_exe: &OsStr, pkg_name: &str) -> Result<
     python_exe = python_exe,
     pkg_name = pkg_name
   );
-  // todo(tmfink): make compatible with python 2 and 3
+
+  // Support both Python 2 and 3
   let cmd = format!(
     r#"
 from importlib import import_module
-from pathlib import Path
-print(Path(import_module("{}").__file__).parent)
+from os.path import dirname
+print(dirname(import_module("{}").__file__))
 exit()
 "#,
     pkg_name

--- a/src/config.rs
+++ b/src/config.rs
@@ -237,7 +237,7 @@ fn get_sudachi_py_package_path() -> Result<String, SudachiDictErr> {
   }
 }
 
-fn create_default_link_for_sudachidict_core() -> Result<(), SudachiDictErr> {
+pub fn create_default_link_for_sudachidict_core() -> Result<(), SudachiDictErr> {
   get_sudachi_dict_path()?;
   if !success_import(SUDACHIDICT_CORE_PKG_NAME) {
     return Err(SudachiDictErr::NotFoundSudachiDictCoreErr);
@@ -249,7 +249,7 @@ fn create_default_link_for_sudachidict_core() -> Result<(), SudachiDictErr> {
     return Err(SudachiDictErr::SetDefaultDictErr);
   }
 
-  set_default_dict_package(SUDACHIDICT_CORE_PKG_NAME);
+  set_default_dict_package(SUDACHIDICT_CORE_PKG_NAME)?;
   Ok(())
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -78,7 +78,7 @@ impl Config {
 
   pub fn setup(path: Option<&str>, resource_dir: Option<&str>) -> Result<Config, ConfigErr> {
     let mut config = Config::empty()?;
-    let default_setting_file = config.DEFAULT_SETTINGFILE.to_path_buf();
+    let default_setting_file = &config.DEFAULT_SETTINGFILE;
     if path.is_none() {
       resources::write_sudachi_json(&default_setting_file)?;
     }
@@ -214,7 +214,7 @@ fn get_python_package_path(
 
   // No python specified; try these in order
   const TRY_PYTHON_NAMES: &[&str] = &["python3", "python", "python2"];
-  for python_exe in TRY_PYTHON_NAMES.into_iter() {
+  for python_exe in TRY_PYTHON_NAMES.iter() {
     if let Ok(child) = get_python_package_path_helper(python_exe.as_ref(), pkg_name) {
       return Ok(child);
     }

--- a/src/dictionary.rs
+++ b/src/dictionary.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsStr;
 use std::io::Error as IOError;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
@@ -72,9 +73,11 @@ impl Dictionary {
   pub fn setup(
     config_path: Option<&str>,
     resource_dir: Option<&str>,
+    python_exe: Option<&OsStr>,
   ) -> Result<Dictionary, DictionaryErr> {
     let mut config = Config::setup(config_path, resource_dir)?;
-    let mut system_dictionary = Dictionary::read_system_dictionary(config.system_dict_path()?)?;
+    let mut system_dictionary =
+      Dictionary::read_system_dictionary(config.system_dict_path(python_exe)?)?;
 
     let char_category = Dictionary::read_character_definition(config.char_def_path()?)?;
     system_dictionary

--- a/src/dictionary_lib/dictionary_builder.rs
+++ b/src/dictionary_lib/dictionary_builder.rs
@@ -4,7 +4,6 @@ use std::io::{BufRead, Cursor, Error as IOError, Seek, SeekFrom, Write};
 use std::num::ParseIntError;
 use std::str::FromStr;
 
-use csv;
 use log::{error, info, warn};
 use regex::{Captures, Error as RegexError, Regex};
 use thiserror::Error;

--- a/src/dictionary_lib/double_array_lexicon.rs
+++ b/src/dictionary_lib/double_array_lexicon.rs
@@ -113,7 +113,7 @@ impl DoubleArrayLexicon {
         continue;
       }
       let surface = self.get_word_info(word_id).surface;
-      let ms = tokenizer.tokenize(&surface, &None, None);
+      let ms = tokenizer.tokenize(&surface, None, None);
       if let Some(ms) = ms {
         let mut cost = ms.get_internal_cost() + USER_DICT_COST_PER_MORPH * ms.len() as i16;
         cost = min(cost, SIGNED_SHORT_MAX);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,18 +8,18 @@
 //! // using `system_core.dic` or `system_full.dic` version 20190781
 //! // you may not be able to replicate this particular example due to dictionary you use
 //!
-//! for m in tokenizer.tokenize("国家公務員", &Some(SplitMode::C), None).unwrap() {
+//! for m in tokenizer.tokenize("国家公務員", Some(SplitMode::C), None).unwrap() {
 //!     println!("{}", m.surface());
 //! };
 //! // => 国家公務員
 //!
-//! for m in tokenizer.tokenize("国家公務員", &Some(SplitMode::B), None).unwrap() {
+//! for m in tokenizer.tokenize("国家公務員", Some(SplitMode::B), None).unwrap() {
 //!     println!("{}", m.surface());
 //! };
 //! // => 国家
 //! // => 公務員
 //!
-//! for m in tokenizer.tokenize("国家公務員", &Some(SplitMode::A), None).unwrap() {
+//! for m in tokenizer.tokenize("国家公務員", Some(SplitMode::A), None).unwrap() {
 //!     println!("{}", m.surface());
 //! };
 //! // => 国家
@@ -28,7 +28,7 @@
 //!
 //! // Morpheme information
 //!
-//! let m = tokenizer.tokenize("食べ", &Some(SplitMode::A), None).unwrap().get(0).unwrap();
+//! let m = tokenizer.tokenize("食べ", Some(SplitMode::A), None).unwrap().get(0).unwrap();
 //! println!("{}", m.surface());
 //! // => 食べ
 //! println!("{}", m.dictionary_form());
@@ -40,13 +40,13 @@
 //!
 //! // Normalization
 //!
-//! println!("{}", tokenizer.tokenize("附属", &Some(SplitMode::A), None).unwrap().get(0).unwrap().normalized_form());
+//! println!("{}", tokenizer.tokenize("附属", Some(SplitMode::A), None).unwrap().get(0).unwrap().normalized_form());
 //! // => 付属
 //!
-//! println!("{}", tokenizer.tokenize("SUMMER", &Some(SplitMode::A), None).unwrap().get(0).unwrap().normalized_form());
+//! println!("{}", tokenizer.tokenize("SUMMER", Some(SplitMode::A), None).unwrap().get(0).unwrap().normalized_form());
 //! // => サマー
 //!
-//! println!("{}", tokenizer.tokenize("シュミレーション", &Some(SplitMode::A), None).unwrap().get(0).unwrap().normalized_form());
+//! println!("{}", tokenizer.tokenize("シュミレーション", Some(SplitMode::A), None).unwrap().get(0).unwrap().normalized_form());
 //! // => シミュレーション
 //! ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! ```
 //! use sudachiclone::prelude::*;
 //!
-//! let dictionary = Dictionary::setup(None, None).unwrap();
+//! let dictionary = Dictionary::setup(None, None, None).unwrap();
 //! let tokenizer = dictionary.create();
 //!
 //! // Multi-granular tokenization

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,6 @@ const QUIET_ARG: &str = "quiet";
 const PRINT_ALL_ARG: &str = "print_all";
 const SYSTEM_DIC_ARG: &str = "system_dic";
 const VERBOSE_ARG: &str = "verbose";
-const VERSION_ARG: &str = "version";
 
 fn unwrap<T, E: Error>(t: Result<T, E>) -> T {
   match t {
@@ -78,11 +77,6 @@ fn tokenize_loop<R: BufRead, W: Write>(
 }
 
 fn tokenize(args: &ArgMatches) {
-  if args.is_present(VERSION_ARG) {
-    print_version();
-    return;
-  }
-
   let mode = match args.value_of(MODE_ARG) {
     Some("A") => Some(SplitMode::A),
     Some("B") => Some(SplitMode::B),
@@ -173,10 +167,6 @@ fn ubuild(args: &ArgMatches) {
   unwrap(builder.build(&lexicon_paths, &mut writer));
 }
 
-fn print_version() {
-  println!("sudachi {}", crate_version!())
-}
-
 fn in_files_validator(in_file: String) -> Result<(), String> {
   if Path::new(&in_file).is_file() {
     Ok(())
@@ -259,6 +249,7 @@ fn setup_logging(matches: &clap::ArgMatches) {
 }
 
 fn main() {
+  let version_string = format!("{}", crate_version!());
   let tokenize_subcommand = SubCommand::with_name(TOKENIZE_SUB_CMD)
     .about("Tokenize Text")
     .help_message("(default) see `tokenize -h`")
@@ -287,17 +278,13 @@ fn main() {
         .help("print all of the fields"),
     )
     .arg(
-      Arg::with_name(VERSION_ARG)
-        .short("V")
-        .help("print sudachipy version"),
-    )
-    .arg(
       Arg::with_name(IN_FILES_ARG)
         .takes_value(true)
         .multiple(true)
         .help("text written in utf-8")
         .validator(in_files_validator),
     )
+    .version(version_string.as_str())
     .add_python_exe_arg();
 
   let link_subcommand = SubCommand::with_name(LINK_SUB_CMD)

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,7 @@ fn tokenize(args: &ArgMatches) {
   loop {
     while let Ok(_) = stdin().read_line(&mut input) {
       for line in input.trim().split('\n') {
-        if let Some(morpheme_list) = tokenizer.tokenize(line, &mode, None) {
+        if let Some(morpheme_list) = tokenizer.tokenize(line, mode, None) {
           for morpheme in morpheme_list {
             println!("{}", morpheme.to_string(print_all).join("\t"));
           }

--- a/src/main.rs
+++ b/src/main.rs
@@ -298,8 +298,7 @@ fn main() {
         .help("text written in utf-8")
         .validator(in_files_validator),
     )
-    .add_python_exe_arg()
-    .add_log_args();
+    .add_python_exe_arg();
 
   let link_subcommand = SubCommand::with_name(LINK_SUB_CMD)
     .about("Link Default Dict Package")
@@ -312,8 +311,7 @@ fn main() {
         .default_value("core")
         .help("dict dict"),
     )
-    .add_python_exe_arg()
-    .add_log_args();
+    .add_python_exe_arg();
 
   let build_subcommand = SubCommand::with_name(BUILD_SUB_CMD)
     .about("Build Sudachi Dictionary")
@@ -353,8 +351,7 @@ fn main() {
       Arg::with_name(IN_FILES_ARG)
         .takes_value(true)
         .help("source files with CSV format (one of more)"),
-    )
-    .add_log_args();
+    );
 
   let ubuild_subcommand = SubCommand::with_name(UBUILD_SUB_CMD)
     .about("Build User Dictionary")
@@ -383,8 +380,7 @@ fn main() {
       Arg::with_name(IN_FILES_ARG)
         .takes_value(true)
         .help("source files with CSV format (one of more)"),
-    )
-    .add_log_args();
+    );
 
   let mut app = App::new("Japanese Morphological Analyzer")
     .subcommand(tokenize_subcommand)

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,6 @@ use std::str::FromStr;
 
 use clap::{crate_name, crate_version, App, Arg, ArgMatches, SubCommand};
 use log::info;
-use stderrlog;
 
 use sudachiclone::config::{create_default_link_for_sudachidict_core, Config};
 use sudachiclone::dictionary::Dictionary;
@@ -249,7 +248,6 @@ fn setup_logging(matches: &clap::ArgMatches) {
 }
 
 fn main() {
-  let version_string = format!("{}", crate_version!());
   let tokenize_subcommand = SubCommand::with_name(TOKENIZE_SUB_CMD)
     .about("Tokenize Text")
     .help_message("(default) see `tokenize -h`")
@@ -284,7 +282,7 @@ fn main() {
         .help("text written in utf-8")
         .validator(in_files_validator),
     )
-    .version(version_string.as_str())
+    .version(crate_version!())
     .add_python_exe_arg();
 
   let link_subcommand = SubCommand::with_name(LINK_SUB_CMD)

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -250,6 +250,7 @@ mod tests {
     Dictionary::setup(
       Some(config_path.to_str().unwrap()),
       Some(resource_dir.to_str().unwrap()),
+      None,
     )
     .unwrap()
   }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -15,19 +15,29 @@ use super::plugin::path_rewrite_plugin::{PathRewritePlugin, RewritePath};
 use super::utf8_input_text::{InputText, UTF8InputText};
 use super::utf8_input_text_builder::UTF8InputTextBuilder;
 
+/// Able to tokenize Japanese text
 pub trait CanTokenize {
   fn tokenize<T: AsRef<str>>(
     &self,
     text: T,
-    mode: &Option<SplitMode>,
+    mode: Option<SplitMode>,
     logger: Option<Box<dyn Log>>,
   ) -> Option<MorphemeList>;
 }
 
-#[derive(PartialEq)]
+/// How to split text
+///
+/// For moree details, see the
+/// [sudachi documentation](https://github.com/WorksApplications/sudachi#the-modes-of-splitting)
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum SplitMode {
+  /// Divide into the shortest units equivalent to the UniDic short unit
   A,
+
+  /// Extract middle units
   B,
+
+  /// Extract named entities
   C,
 }
 
@@ -104,14 +114,14 @@ impl Tokenizer {
   fn split_path(
     &self,
     path: Vec<Arc<Mutex<LatticeNode>>>,
-    mode: &SplitMode,
+    mode: SplitMode,
   ) -> Vec<Arc<Mutex<LatticeNode>>> {
-    if mode == &SplitMode::C {
+    if mode == SplitMode::C {
       return path;
     }
     let mut new_path = vec![];
     for node in path {
-      let word_ids = if mode == &SplitMode::A {
+      let word_ids = if mode == SplitMode::A {
         node.lock().unwrap().get_word_info().a_unit_split
       } else {
         node.lock().unwrap().get_word_info().b_unit_split
@@ -143,7 +153,7 @@ impl<'a, C: CanTokenize + ?Sized> CanTokenize for &'a C {
   fn tokenize<T: AsRef<str>>(
     &self,
     text: T,
-    mode: &Option<SplitMode>,
+    mode: Option<SplitMode>,
     logger: Option<Box<dyn Log>>,
   ) -> Option<MorphemeList> {
     (**self).tokenize(text, mode, logger)
@@ -154,7 +164,7 @@ impl CanTokenize for Tokenizer {
   fn tokenize<T: AsRef<str>>(
     &self,
     text: T,
-    mode: &Option<SplitMode>,
+    mode: Option<SplitMode>,
     logger: Option<Box<dyn Log>>,
   ) -> Option<MorphemeList> {
     if text.as_ref().is_empty() {
@@ -164,7 +174,7 @@ impl CanTokenize for Tokenizer {
       set_boxed_logger(logger).unwrap();
     }
 
-    let mode = mode.as_ref().unwrap_or(&SplitMode::C);
+    let mode = mode.unwrap_or(SplitMode::C);
     let mut builder = UTF8InputTextBuilder::new(text.as_ref(), Arc::clone(&self.grammar));
     for plugin in self.input_text_plugins.iter() {
       if plugin.rewrite(&mut builder).is_err() {
@@ -253,14 +263,14 @@ mod tests {
   #[test]
   fn test_tokenize_small_katanana_only() {
     let (_, tokenizer) = &build_tokenizer();
-    let morpheme_list = tokenizer.tokenize("ァ", &None, None).unwrap();
+    let morpheme_list = tokenizer.tokenize("ァ", None, None).unwrap();
     assert_eq!(1, morpheme_list.len());
   }
 
   #[test]
   fn test_part_of_speech() {
     let (dictionary, tokenizer) = &build_tokenizer();
-    let morpheme_list = tokenizer.tokenize("京都", &None, None).unwrap();
+    let morpheme_list = tokenizer.tokenize("京都", None, None).unwrap();
     assert_eq!(1, morpheme_list.len());
     let pid = morpheme_list.get(0).unwrap().part_of_speech_id() as usize;
     assert!(
@@ -284,7 +294,7 @@ mod tests {
   #[test]
   fn test_get_word_id() {
     let (_, tokenizer) = &build_tokenizer();
-    let morpheme_list = tokenizer.tokenize("京都", &None, None).unwrap();
+    let morpheme_list = tokenizer.tokenize("京都", None, None).unwrap();
     let morpheme = morpheme_list.get(0).unwrap();
     assert_eq!(1, morpheme_list.len());
     assert_eq!(
@@ -300,7 +310,7 @@ mod tests {
     );
 
     let word_id = &morpheme.get_word_id();
-    let morpheme_list = tokenizer.tokenize("ぴらる", &None, None).unwrap();
+    let morpheme_list = tokenizer.tokenize("ぴらる", None, None).unwrap();
     let morpheme = morpheme_list.get(0).unwrap();
     assert_eq!(1, morpheme_list.len());
     assert!(word_id != &morpheme.get_word_id());
@@ -316,22 +326,22 @@ mod tests {
       morpheme.part_of_speech()
     );
 
-    let morpheme_list = tokenizer.tokenize("京", &None, None).unwrap();
+    let morpheme_list = tokenizer.tokenize("京", None, None).unwrap();
     assert_eq!(1, morpheme_list.len());
   }
 
   #[test]
   fn test_get_dictionary_id() {
     let (_, tokenizer) = &build_tokenizer();
-    let morpheme_list = tokenizer.tokenize("京都", &None, None).unwrap();
+    let morpheme_list = tokenizer.tokenize("京都", None, None).unwrap();
     let morpheme = morpheme_list.get(0).unwrap();
     assert_eq!(Some(0), morpheme.dictionary_id());
 
-    let morpheme_list = tokenizer.tokenize("ぴらる", &None, None).unwrap();
+    let morpheme_list = tokenizer.tokenize("ぴらる", None, None).unwrap();
     let morpheme = morpheme_list.get(0).unwrap();
     assert_eq!(Some(1), morpheme.dictionary_id());
 
-    let morpheme_list = tokenizer.tokenize("京", &None, None).unwrap();
+    let morpheme_list = tokenizer.tokenize("京", None, None).unwrap();
     let morpheme = morpheme_list.get(0).unwrap();
     assert_eq!(None, morpheme.dictionary_id());
   }
@@ -339,16 +349,16 @@ mod tests {
   #[test]
   fn test_tokenize_kanji_alphabet_word() {
     let (_, tokenizer) = &build_tokenizer();
-    assert_eq!(1, tokenizer.tokenize("特a", &None, None).unwrap().len());
-    assert_eq!(1, tokenizer.tokenize("ab", &None, None).unwrap().len());
-    assert_eq!(2, tokenizer.tokenize("特ab", &None, None).unwrap().len());
+    assert_eq!(1, tokenizer.tokenize("特a", None, None).unwrap().len());
+    assert_eq!(1, tokenizer.tokenize("ab", None, None).unwrap().len());
+    assert_eq!(2, tokenizer.tokenize("特ab", None, None).unwrap().len());
   }
 
   #[test]
   fn test_tokenize_multiline_sentences() {
     let (_, tokenizer) = &build_tokenizer();
     let ms = tokenizer
-      .tokenize("我輩は猫である。\n名前はまだない。", &None, None)
+      .tokenize("我輩は猫である。\n名前はまだない。", None, None)
       .unwrap();
     assert_eq!(17, ms.len());
     assert_eq!(


### PR DESCRIPTION
Makes the following improvements/bug fixes:

- `tokenize` subcommand
    - Allow user to specify python executable
    - Terminate on EOF correctly
    - Support for optional output file
- Python
    - Support Python 2 and 3
    - Try multiple python executable names by default
    - Only link the python modules when running `link` subcommand
- Make `SplitMode` enum `Copy`; pass by value in API
- Do not default to the "tokenize" subcommand
- Refactor duplicated constants into global constants
- Add logging support to executable
- Update readme with changes