### PR TITLE
 Eliminate delays due to variable access by subscripts in Rust specifications

### DIFF
--- a/src/dictionary_lib/grammar.rs
+++ b/src/dictionary_lib/grammar.rs
@@ -43,13 +43,7 @@ impl Grammar {
     } else {
       let mut buf = vec![0i16; left_id_size * right_id_size];
       reader.read_i16_into::<LittleEndian>(&mut buf)?;
-      let mut matrix_view = vec![vec![0; right_id_size]; left_id_size];
-      for i in 0..left_id_size {
-        for j in 0..right_id_size {
-          matrix_view[i][j] = buf[(i * left_id_size) + j];
-        }
-      }
-      matrix_view
+      buf.chunks(right_id_size).map(|chunk| chunk.to_vec()).collect()
     };
 
     Ok(Grammar {


### PR DESCRIPTION
reshape機能でbufを2次元配列に変換

```
values[1][32] 
```
こういうアクセスの仕方をすると遅くなるそうです。
https://llogiq.github.io/2017/03/06/lifetime.html
言語仕様バグ？　上手く連続性を保ったMAPが作れないみたいです。

ライブラリとして使えるSudachiクローンを作っていただき有難うございます。